### PR TITLE
<fix> 자동완성 키워드 검색 에러

### DIFF
--- a/src/components/search/SearchHeader.jsx
+++ b/src/components/search/SearchHeader.jsx
@@ -82,7 +82,7 @@ const SearchHeader = () => {
             <ArrowBackIcon onClick={() => navigate(-1)} />
           </NavItem>
           <StForm onKeyPress={onCheckEnterHandler}>
-            <NavItem>
+            <NavItem ref={searchInput}>
               {keyword !== undefined ? (
                 <SearchInput
                   id="keyword"
@@ -109,7 +109,6 @@ const SearchHeader = () => {
                     setKeywordValue(e.target.value);
                     onAutoCompleteHandler(e);
                   }}
-                  ref={searchInput}
                 />
               )}
               {autoComplete && (


### PR DESCRIPTION
자동완성 키워드를 누르면 검색이 되도록 검색 액션을 디스패치 해놨었다. 하지만 실행이 안되고 있었습니다.

useRef로 감지하는 컴포넌트 외부영역을 누르면 자동완성 창이 닫히게 하는 기능을 구현하니깐 
이벤트가 충돌이 나서 생기는 오류였습니다! 

useRef로 감지하는 컴포넌트의 영역을 input으로만 해놨는데 
영역을 넓혀서 input + 자동완성 컨테이너 까지 감지하도록 ref를 설정해주니 
기존의 자동완성 키워드 검색이 잘 되는 것을 확인할 수 있었습니다! 

# 에러 
![ezgif-5-a2e04b0005](https://user-images.githubusercontent.com/72599761/190207253-d53683fe-1e48-419b-92f1-07619b95ff08.gif)

# 에러 고친 후 
![ezgif-5-87a179b96c](https://user-images.githubusercontent.com/72599761/190207238-2b8d8868-44b9-4098-9223-135c7d532c0f.gif)

useRef로 컴포넌트 영역을 얼만큼 감지할 것이냐가 중요하다는 것을 알게되었습니다!