### PR TITLE
<fix> 카카오톡 공유하기 에러

### DIFF
--- a/src/components/market/detail/DetailInfo.jsx
+++ b/src/components/market/detail/DetailInfo.jsx
@@ -50,9 +50,8 @@ const DetailInfo = () => {
           description: `${item.content}`,
           imageUrl: `${item.itemImgs[0]}`,
           link: {
-            // 배포한 주소
-            mobileWebUrl: "공유할 url 주소",
-            webUrl: "공유할 url주소",
+            mobileWebUrl: "https://d13psgq1alfu1t.cloudfront.net/",
+            webUrl: "https://d13psgq1alfu1t.cloudfront.net/",
           },
         },
       });


### PR DESCRIPTION
카카오톡 공유하기 에러 해결 
배포 도메인이 달라서 생긴 오류였습니다. 
S3+클라우드 프론트로 적용한 배포 도메인을 적용해주니 에러 해결되었습니다! 