### PR TITLE
토글 조건부 렌더링과 블링킹 에러 해결

### DIFF
--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -22,19 +22,17 @@ const Search = () => {
   }, [autoSaveState]);
 
   useEffect(() => {
-    setIsToggled(isToggled);
     dispatch(__toggleStateRecentKeyword());
-  }, [dispatch, setIsToggled, isToggled]);
+  }, [dispatch]);
 
   const onToggleHandler = () => {
     if (isToggled) {
+      apis.put_toggle_state();
       dispatch(toggleOff());
-      apis.put_toggle_state();
     } else {
-      dispatch(toggleOn());
       apis.put_toggle_state();
+      dispatch(toggleOn());
     }
-    setIsToggled((prev) => !prev);
   };
 
   const onAllRecentDeleteHandler = () => {

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -61,7 +61,7 @@ const Search = () => {
             </AllDeleteButton>
           </ButtonsWrapper>
         </TitleWrapper>
-        <RecentSearchList></RecentSearchList>
+        {isToggled && <RecentSearchList></RecentSearchList>}
       </RecentSearchWrapper>
     </SearchWrapper>
   );


### PR DESCRIPTION
토글 블링킹 현상은 중복으로 렌더링 되는 부분이 있었습니다. 이 부분을 해결하니 매끄럽게 토글 이벤트가 일어납니다. 

토글이 꺼져있는지 켜져있는지 서버에서 받아온 상태값을 리덕스의 전역 state에 저장하고
구독하고 있는 컴포넌트에 토글 상태값을 전달해줘서 그 상태값으로 조건부 렌더링을 하니 토글 켤 때는 최근 검색어 리스트가 보이고, 끌 때는 최근 검색어가 안 보이게 되었습니다. 