### PR TITLE
<fix> GlobalSelect 외부영역 누르면 닫히지 않는 에러

### DIFF
--- a/src/components/elements/GlobalSelect.jsx
+++ b/src/components/elements/GlobalSelect.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { ReactComponent as DropDownIcon } from "../../assets/icons/arrow_drop_down.svg";
 
@@ -20,6 +20,21 @@ const GlobalSelect = ({
     setSelected(e.target.getAttribute("value"));
   };
 
+  const selectRef = useRef();
+
+  useEffect(() => {
+    const listener = (event) => {
+      if (selectRef.current && !selectRef.current.contains(event.target)) {
+        setIsShowOptions(false);
+      }
+    };
+    document.addEventListener("mousedown", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+    };
+  }, [selectRef]);
+
   return (
     <>
       <SelectorWrapper
@@ -27,6 +42,7 @@ const GlobalSelect = ({
         width={width}
         height={height}
         onClick={() => setIsShowOptions((prev) => !prev)}
+        ref={selectRef}
       >
         <DropDownIconSet color={color} />
         <Label>{currentOption}</Label>


### PR DESCRIPTION
useRef로 컴포넌트 감지한 외부 영역 눌렀을 때 닫히도록 useEffect를 활용하여 이벤트 리스너 등록 후 해제 