### PR TITLE
수정 페이지에 수정 전 이미지 슬라이드가 없는 에러 수정 

### DIFF
--- a/src/components/elements/GlobalImgSlider.jsx
+++ b/src/components/elements/GlobalImgSlider.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import styled from "styled-components";
 import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
 
-const ImgView = ({ imgUrls }) => {
+const GlobalImgSlider = ({ imgUrls }) => {
   const [currImg, setCurrImg] = useState(0);
   const [lastImg, setLastImg] = useState(imgUrls.length - 1);
 
@@ -114,4 +114,4 @@ const ImgPreview = styled.img`
   transition: all 3ms ease;
 `;
 
-export default ImgView;
+export default GlobalImgSlider;

--- a/src/components/elements/GlobalSelect.jsx
+++ b/src/components/elements/GlobalSelect.jsx
@@ -88,7 +88,7 @@ const SelectorWrapper = styled.div`
   border: 2px solid
     ${({ color, theme }) => (color === "gray" ? theme.gray : theme.mainColor)};
   cursor: pointer;
-  z-index: 101;
+  z-index: 3;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -130,7 +130,7 @@ const SelectOptions = styled.ul`
   margin: 0.4rem 0 0.1rem -1.5rem;
   font-size: 1.4rem;
   background-color: white;
-  z-index: 100;
+  z-index: 2;
   border: 2px solid
     ${({ color, theme }) => (color === "gray" ? theme.gray : theme.mainColor)};
   text-align: left;

--- a/src/components/market/update/Update.jsx
+++ b/src/components/market/update/Update.jsx
@@ -243,6 +243,7 @@ function Update() {
             />
             <ImgWrapper>
               {!isLoading && <ImgSlider imgUrls={itemImgs} />}
+              {isLoading && <ImgSlider imgUrls={state.itemImgs} />}
             </ImgWrapper>
             <FixButton content={"게시글 수정하기"} />
           </Container>


### PR DESCRIPTION
수정 페이지에 기존 이미지 슬라이드가 존재하지 않습니다 

![image](https://user-images.githubusercontent.com/72599761/191542864-97b2aee2-8c4c-4ada-a60f-add290fc3b36.png)

파일 선택하기 전 state로 전달받은 imgItems를 imgSlider의 props로 바로 넘겨주니 해결되었습니다. 

![image](https://user-images.githubusercontent.com/72599761/191543128-7ce48345-7aae-45f3-897d-783575f9fc35.png)
