### PR TITLE
<feat> 메인 배너 이미지 슬라이더 구현

### DIFF
--- a/src/components/elements/GlobalImgSlider2.jsx
+++ b/src/components/elements/GlobalImgSlider2.jsx
@@ -5,13 +5,27 @@ import "slick-carousel/slick/slick-theme.css";
 import { v4 as uuidv4 } from "uuid";
 import styled from "styled-components";
 
-const SimpleSlider = ({ itemImgs }) => {
+const GlobalImgSlider2 = ({
+  itemImgs,
+  autoplay = false,
+  fade = false,
+  autoplaySpeed = 0,
+  nextArrow,
+  prevArrow,
+}) => {
   const settings = {
     dots: true,
     infinite: true,
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
+    arrows: true,
+    fade: fade,
+    autoplay: autoplay,
+    autoplaySpeed: autoplaySpeed,
+    lazyLoad: true,
+    nextArrow: nextArrow,
+    prevArrow: prevArrow,
   };
   return (
     <StyledSlider {...settings}>
@@ -24,27 +38,29 @@ const SimpleSlider = ({ itemImgs }) => {
 };
 
 const StyledSlider = styled(Slider)`
+  width: 100%;
   margin-bottom: 1.9rem;
+  position: relative;
 `;
 
 const Img = styled.img`
   width: 100%;
-  object-fit: contain;
+  object-fit: fill;
   background-color: ${({ theme }) => theme.lightgray};
   @media screen and (min-width: 1024px) {
     /* Desktop */
-    height: 35.2rem;
+    height: 33rem;
   }
 
   @media screen and (min-width: 768px) and (max-width: 1023px) {
     /* Tablet */
-    height: 28.2rem;
+    height: 22rem;
   }
 
   @media (max-width: 767px) {
     /* Mobile */
-    height: 25.2rem;
+    height: 14rem;
   }
 `;
 
-export default SimpleSlider;
+export default GlobalImgSlider2;

--- a/src/components/elements/buttons/NextArrowButton.jsx
+++ b/src/components/elements/buttons/NextArrowButton.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import styled from "styled-components";
+import { IoIosArrowForward } from "react-icons/io";
+
+const NextArrowButton = ({ onClick }) => {
+  return (
+    <>
+      <Button onClick={onClick}>
+        <IoIosArrowForward />
+      </Button>
+    </>
+  );
+};
+
+const Button = styled.div`
+  background: ${({ theme }) => theme.white};
+  border-radius: 0.2rem;
+  width: 2rem;
+  height: 3rem;
+  font-size: 2rem;
+  opacity: 0.9;
+  display: block;
+  text-shadow: center;
+  border: none;
+  position: absolute;
+  cursor: pointer;
+  transition: all 3ms ease;
+  z-index: 3;
+  color: ${({ theme }) => theme.darkgray};
+  @media screen and (min-width: 1024px) {
+    /* Desktop */
+    width: 4rem;
+    height: 5rem;
+    font-size: 4rem;
+    top: 14rem;
+    right: 1rem;
+  }
+
+  @media screen and (min-width: 768px) and (max-width: 1023px) {
+    /* Tablet */
+    width: 3rem;
+    height: 4rem;
+    font-size: 3rem;
+    top: 9rem;
+    right: 1rem;
+  }
+
+  @media (max-width: 767px) {
+    /* Mobile */
+    top: 5rem;
+    right: 1rem;
+  }
+`;
+
+export default NextArrowButton;

--- a/src/components/elements/buttons/PrevArrowButton.jsx
+++ b/src/components/elements/buttons/PrevArrowButton.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import styled from "styled-components";
+import { IoIosArrowBack } from "react-icons/io";
+
+const PrevArrowButton = ({ onClick }) => {
+  return (
+    <>
+      <Button onClick={onClick}>
+        <IoIosArrowBack />
+      </Button>
+    </>
+  );
+};
+
+export default PrevArrowButton;
+
+const Button = styled.div`
+  background: ${({ theme }) => theme.white};
+  border-radius: 0.2rem;
+  width: 2rem;
+  height: 3rem;
+  opacity: 0.9;
+  display: block;
+  position: absolute;
+  cursor: pointer;
+  transition: all 3ms ease;
+  z-index: 3;
+  color: ${({ theme }) => theme.darkgray};
+  font-size: 2rem;
+  @media screen and (min-width: 1024px) {
+    /* Desktop */
+    width: 4rem;
+    height: 5rem;
+    font-size: 4rem;
+    top: 14rem;
+    left: 1rem;
+  }
+
+  @media screen and (min-width: 768px) and (max-width: 1023px) {
+    /* Tablet */
+    width: 3rem;
+    height: 4rem;
+    font-size: 3rem;
+    top: 9rem;
+    left: 1rem;
+  }
+
+  @media (max-width: 767px) {
+    /* Mobile */
+    top: 5rem;
+    left: 1rem;
+  }
+`;

--- a/src/components/market/detail/DetailInfo.jsx
+++ b/src/components/market/detail/DetailInfo.jsx
@@ -4,10 +4,10 @@ import {
   __deletePost,
 } from "../../../redux/modules/market/postSlice";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import ItemZzimButton from "../../elements/buttons/ItemZzimButton";
-import SimpleSlider from "./SimpleSlider";
+import ImgSlider from "../../elements/GlobalImgSlider2";
 import Comment from "../comment/Comment";
 import FixButton from "../../elements/buttons/FixButton";
 import FixThreeButton from "../../elements/buttons/FixThreeButton";
@@ -120,7 +120,7 @@ const DetailInfo = () => {
         {isModal ? (
           <GlobalModal content={"로그인 하세요"} name={"로그인"} />
         ) : null}
-        <SimpleSlider itemImgs={itemImgs} />
+        <ImgSlider itemImgs={itemImgs} />
         <DetailWrapper>
           <InfoWrapper>
             <P>

--- a/src/components/market/main/MainBanner.jsx
+++ b/src/components/market/main/MainBanner.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import ImgSlider from "../../elements/GlobalImgSlider2";
+import styled from "styled-components";
+import NextArrowButton from "../../elements/buttons/NextArrowButton";
+import PrevArrowButton from "../../elements/buttons/PrevArrowButton";
+
+const MainBanner = () => {
+  return (
+    <>
+      <ImgWrapper>
+        <ImgSlider
+          itemImgs={[
+            "https://i.postimg.cc/QxKVp4Hp/2.png",
+            "https://i.postimg.cc/FKzqPsBq/3.png",
+          ]}
+          fade={true}
+          autoplaySpeed={3000}
+          autoplay={true}
+          prevArrow={<PrevArrowButton />}
+          nextArrow={<NextArrowButton />}
+        />
+      </ImgWrapper>
+    </>
+  );
+};
+
+const ImgWrapper = styled.div`
+  padding: 8.4rem 1.6rem 0rem 1.6rem;
+`;
+
+export default MainBanner;

--- a/src/components/market/main/MainContainer.jsx
+++ b/src/components/market/main/MainContainer.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
-import ItemList from '../../market/main/ItemList';
-import styled from 'styled-components';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useState, useEffect, useRef } from "react";
+import ItemList from "../../market/main/ItemList";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
 import {
   getData,
   __getPost,
@@ -9,9 +9,9 @@ import {
   __getItemCategories,
   addPage,
   doubleListToZero,
-} from '../../../redux/modules/market/postSlice';
-import option from './Option';
-import Select from '../../elements/GlobalSelect';
+} from "../../../redux/modules/market/postSlice";
+import option from "./Option";
+import Select from "../../elements/GlobalSelect";
 
 const MainContainer = () => {
   const dispatch = useDispatch();
@@ -30,15 +30,15 @@ const MainContainer = () => {
   const categoryPage = useSelector((state) => state.marketPost.page);
 
   console.log(doubleList);
-  const [state, setState] = useState('');
+  const [state, setState] = useState("");
   const [page, setPage] = useState(0);
   const lastIntersectingData = useRef(null);
 
   const handleChange = (event) => {
     setState(event.target.value);
-    let e = document.getElementById('selectElementID');
+    let e = document.getElementById("selectElementID");
     let text = e.options[e.selectedIndex].text;
-    localStorage.setItem('petCategory', `${text}`);
+    localStorage.setItem("petCategory", `${text}`);
     setPage(0);
     dispatch(doubleListToZero());
   };
@@ -59,7 +59,7 @@ const MainContainer = () => {
   const onIntersect = (entries, observer) => {
     entries.forEach((entry) => {
       if (entry.isIntersecting) {
-        console.log('!?!?!?');
+        console.log("!?!?!?");
         setPage((page) => page + 1);
         dispatch(addPage());
         // 현재 타겟을 observe한다.
@@ -68,28 +68,28 @@ const MainContainer = () => {
     });
   };
 
-  const itemCategory = localStorage.getItem('itemCategory');
-  const petCategory = localStorage.getItem('petCategory');
+  const itemCategory = localStorage.getItem("itemCategory");
+  const petCategory = localStorage.getItem("petCategory");
 
   useEffect(() => {
     if (petCategory === null && itemCategory === null) {
       dispatch(__getPost({ page: page }));
     }
-    if (petCategory === '강아지' && itemCategory === null) {
-      dispatch(getData({ state: '강아지', page: page }));
+    if (petCategory === "강아지" && itemCategory === null) {
+      dispatch(getData({ state: "강아지", page: page }));
     }
-    if (petCategory === '고양이' && itemCategory === null) {
-      dispatch(getData({ state: '고양이', page: page }));
+    if (petCategory === "고양이" && itemCategory === null) {
+      dispatch(getData({ state: "고양이", page: page }));
     }
-    if (petCategory === '모두' && itemCategory === null) {
+    if (petCategory === "모두" && itemCategory === null) {
       dispatch(__getPost({ page: page }));
     }
     if (petCategory === null && itemCategory !== null) {
       dispatch(__getItemCategories({ itemCategory: itemCategory, page: page }));
     }
     if (petCategory !== null && itemCategory !== null) {
-      console.log('mainContainer');
-      if (petCategory === '모두') {
+      console.log("mainContainer");
+      if (petCategory === "모두") {
         dispatch(
           __getItemCategories({ itemCategory: itemCategory, page: page })
         );
@@ -150,16 +150,16 @@ const MainContainer = () => {
     <>
       <STsection>
         <STh1>멍냥마켓</STh1>
-        <div className='button'>
+        <div className="button">
           <STselect
-            name='choice'
+            name="choice"
             onChange={handleChange}
             defaultValue={option[2].value}
-            id='selectElementID'
+            id="selectElementID"
           >
             {option.map((option) => (
               <option
-                className='option'
+                className="option"
                 key={option.value}
                 value={option.value}
                 name={option.name}
@@ -205,7 +205,7 @@ const STsection = styled.section`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 9rem;
+  padding-top: 5rem;
   margin-bottom: 1rem;
   .button {
     display: flex;

--- a/src/page/market/Main.jsx
+++ b/src/page/market/Main.jsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 import AddPostButton from "../../components/elements/buttons/AddPostButton";
 import GlobalModal from "../../components/elements/GlobalModal";
+import MainBanner from "../../components/market/main/MainBanner";
 
 const Main = () => {
   const navigate = useNavigate();
@@ -22,6 +23,7 @@ const Main = () => {
       {isModal && <GlobalModal content={"로그인이 필요합니다."} />}
       <Header />
       <Layout>
+        <MainBanner />
         <MainContainer />
         {isLogin ? (
           <AddPostButton


### PR DESCRIPTION

![메인이미지슬라이더](https://user-images.githubusercontent.com/72599761/191686063-35e742e6-652f-4c76-8544-326a2992a6b2.gif)


메인 배너 이미지 슬라이더 구현했습니다. 
3초마다 자동으로 다음 이미지로 이동이 가능하고, prev, next버튼을 누르면 이미지가 이동합니다. 
기존의 GlobalImgSlider2에 autoPlay관련된 Props를 추가했고, 커스텀한 prevButton, nextButton도 props에 추가했습니다.   