### PR TITLE
<fix> 스크롤바 유지 에러 해결

### DIFF
--- a/src/components/market/create/Create.jsx
+++ b/src/components/market/create/Create.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { useDispatch } from "react-redux/es/exports";
 import { __addPost } from "../../../redux/modules/market/postSlice";
@@ -23,6 +23,11 @@ function Create() {
 
   const [petCategory, setPetCategory] = useState(PetOption[0].value);
   const [itemCategory, setItemCategory] = useState(ItemOption[0].value);
+
+  const divRef = useRef();
+  useEffect(() => {
+    divRef.current.scrollIntoView();
+  }, []);
 
   useEffect(() => {
     setPetCategory(petCategory);
@@ -119,6 +124,7 @@ function Create() {
 
   return (
     <>
+      <span ref={divRef}></span>
       <FormWrapper>
         <Form onSubmit={handleSubmit(onSubmitHandler)}>
           <TitleWrapper>

--- a/src/components/market/detail/DetailInfo.jsx
+++ b/src/components/market/detail/DetailInfo.jsx
@@ -19,6 +19,7 @@ import EditIcon from "../../../assets/icons/edit_document2.svg";
 import DeleteIcon from "../../../assets/icons/delete.svg";
 import CheckIcon from "../../../assets/icons/check_circle.svg";
 import Accordian from "../../elements/GlobalAccordian";
+import { useRef } from "react";
 
 const DetailInfo = () => {
   const dispatch = useDispatch();
@@ -41,10 +42,11 @@ const DetailInfo = () => {
 
   const moveChat = () => {
     navigate(`/chatRoom/${id}`);
-    console.log(id);
   };
 
+  const divRef = useRef();
   useEffect(() => {
+    divRef.current.scrollIntoView();
     dispatch(__getSinglePost({ id: id }));
   }, []);
 
@@ -142,7 +144,9 @@ const DetailInfo = () => {
           onClick={onDeleteHandler}
         />
       )}
+
       <span ref={divRef}></span>
+
       <DetailInfoWrapper>
         {isModal ? (
           <GlobalModal content={"로그인 하세요"} name={"로그인"} />

--- a/src/components/market/update/Update.jsx
+++ b/src/components/market/update/Update.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux/es/exports";
 import {
@@ -138,8 +138,13 @@ function Update() {
     return setValue(inputId, value);
   };
 
+  const divRef = useRef();
+  useEffect(() => {
+    divRef.current.scrollIntoView();
+  }, []);
   return (
     <>
+      <span ref={divRef}></span>
       <FormWrapper>
         <Form onSubmit={handleSubmit(onUpdateHandler)}>
           <TitleWrapper>

--- a/src/components/myPage/MyPage.jsx
+++ b/src/components/myPage/MyPage.jsx
@@ -1,11 +1,16 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import MyPageChart from "./MyPageChart";
 import Profile from "./Profile";
 import styled from "styled-components";
 
 const MyPage = () => {
+  const divRef = useRef();
+  useEffect(() => {
+    divRef.current.scrollIntoView();
+  }, []);
   return (
     <>
+      <span ref={divRef}></span>
       <MyPageBackgroundWrapper>
         <MyPageWrapper>
           <Profile></Profile>


### PR DESCRIPTION
상세 페이지, 마이페이지, 게시글 작성페이지, 게시글 수정 페이지에 스크롤바 유지 에러 해결 

scrollTop toScroll 등 상단으로 올리는 방법이 많았는데, ref로 감지해야할 대상을 최상단으로 올리지 않아서 그런지 잘 동작하지 않았습니다… 🤣 

scrollIntoView를 쓸 때는 ref로 감지해야할 대상을 최상단에 뒀기 때문에 잘 동작했습니다. 

useRef로 페이지 최상단에 있는 span태그를 감지해서 스크롤바를 span태그 위치로 올리도록 useEffect훅을 이용해서 구현했습니다. 

```jsx
const divRef = useRef();
  useEffect(() => {
    divRef.current.scrollIntoView();
  }, []);

// 페이지 최상단에 ref로 감지하는 span태그 존재.  
<span ref={divRef}></span>
```

#170 