### PR TITLE
<fix> 카카오 로그인 리다이렉트 에러 수정

### DIFF
--- a/src/redux/modules/user/userActions.js
+++ b/src/redux/modules/user/userActions.js
@@ -84,14 +84,16 @@ export const logoutUser = createAsyncThunk(
 
 // 백엔드로 인가코드 보내기
 export const kakaoLogin = createAsyncThunk(
-  'user/kakaoLogin',
-  async (payload, { rejectWithValue }) => {
-    console.log(payload);
+  "user/kakaoLogin",
+  async (payload, { fulfillWithValue, rejectWithValue }) => {
     try {
-      const response = await axios.get(`http://{서버주소}?code=${payload}`);
-      console.log(response); // 토큰을 넘겨받음
-      const ACCESS_TOKEN = response.data.accessToken;
-      localStorage.setItem('kakao-token', ACCESS_TOKEN);
+      const response = await axios.get(
+        `https://fabius-bk.shop/members/kakao/callback?code=${payload}`
+      );
+      const ACCESS_TOKEN = response.headers.authorization;
+      localStorage.setItem("access-token", ACCESS_TOKEN);
+      localStorage.setItem("refresh-token", response.headers.refreshtoken);
+      return fulfillWithValue(response);
     } catch (error) {
       if (error.response && error.response.data.message) {
         return rejectWithValue(error.response.data.message);

--- a/src/routers/Routers.jsx
+++ b/src/routers/Routers.jsx
@@ -26,7 +26,6 @@ const Routers = () => {
         <Route path="/market/detail/:id" element={<MarketDetail />} />
         <Route path="/market/post" element={<MarketPosting />} />
         <Route path="/market/post/:id" element={<MarketPostingUpdate />} />
-        <Route path="/kakao" element={<Kakao />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/search" element={<Search />} />
@@ -37,6 +36,7 @@ const Routers = () => {
         <Route path="/mypage/zzims" element={<MyZzim />} />
         <Route path="/mypage/writings" element={<MyWritings />} />
         <Route path="/mypage/products" element={<MyViewedProucts />} />
+        <Route path="/members/kakao/callback" element={<Kakao />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
1. 카카오 로그인 리다이렉트 에러가 존재 
라우터 처리를 하지 않았서 생긴 에러

2. 서버와도 api 연결

3.   access-token, refresh-token 둘 다 전달 

그 전에는  access-token만 kakao-token이라는 이름으로 전달 