### PR TITLE
<fix> 메인 로고 눌렀을 때 카테고리 초기화 기능 및 메인 텍스트 변경

### DIFF
--- a/src/components/market/main/MainContainer.jsx
+++ b/src/components/market/main/MainContainer.jsx
@@ -64,8 +64,11 @@ const MainContainer = () => {
     });
   };
 
-  const itemCategory = localStorage.getItem("itemCategory");
+  const itemCategoryObj = JSON.parse(localStorage.getItem("itemCategory"));
+  const itemCategory = itemCategoryObj ? itemCategoryObj.itemCategory : null;
   const petCategory = localStorage.getItem("petCategory");
+
+  useEffect(() => {}, [itemCategoryObj]);
 
   useEffect(() => {
     if (petCategory === null && itemCategory === null) {
@@ -142,17 +145,10 @@ const MainContainer = () => {
     doubleList,
   ]);
 
-  const [mainTitle, setMainTitle] = useState("멍냥마켓");
-  useEffect(() => {
-    if (itemCategory) {
-      setMainTitle(itemCategory);
-    }
-  }, [itemCategory]);
-
   return (
     <Wrapper>
       <STsection>
-        <STh1>{mainTitle}</STh1>
+        <STh1>{itemCategory ? itemCategory : "멍냥마켓"}</STh1>
         <div className="button">
           <Select
             optionDatas={option}


### PR DESCRIPTION
# #190 

에러 고치기 전에는 메인 로고를 눌러도 이전에 눌렀던 카테고리가 존재했다. 

에러를 고친 후에는 문제 없이 잘 동작했다. 

멍냥마켓 로고를 눌렀을 때 로컬 스토리지에 존재하는 petCategory, itemCategory  값들을 지워줬다. 

```jsx
<NavItem
            onClick={() => {
              onPathHandler("/");
              window.localStorage.removeItem("petCategory");
              window.localStorage.removeItem("itemCategory");
            }}
          >
            <Logo
              src={process.env.PUBLIC_URL + "/img/logo_gnb2@2x.png"}
              alt="멍냥마켓 로고"
            ></Logo>
          </NavItem>
```

 로컬 스토리지에 itemCategory가 있으면  itemCatgory를 메인화면에 표시하고, 없을 시에 메인 타이틀에 멍냥마켓을 표시하도록 구현했다. 

```jsx
const itemCategoryObj = JSON.parse(localStorage.getItem("itemCategory"));
const itemCategory = itemCategoryObj ? itemCategoryObj.itemCategory : null;

return (
    <Wrapper>
      <STsection>
        <STh1>{itemCategory ? itemCategory : "멍냥마켓"}</STh1>
				....
```

ㄴ